### PR TITLE
Add option to ignore errors associated with incomplete expressions

### DIFF
--- a/src/ErrorListener.js
+++ b/src/ErrorListener.js
@@ -1,11 +1,26 @@
 export default
 class ErrorListener {
 
-  constructor() {
+  /**
+   * Constructor
+   * 
+   * @param  {Object} ignore Errors to ignore
+   */
+  constructor(ignore={}) {
+    // Ignore incomplete expressions?
+    if (ignore.incomplete !== false) ignore.incomplete = true
+    this.ignore = ignore
+
     this.syntaxErrors = []
   }
 
   syntaxError(recognizer, offendingSymbol, line, column, msg, error) {
+    if (this.ignore.incomplete) {
+      // Ignore syntax errors that are often associated with incomplete expressions
+      if (/^missing '.+' at '<EOF>'/.test(msg)) return
+      if (/^mismatched input '<EOF>'/.test(msg)) return
+    }
+
     let expectedTokens
     if (error) {
       expectedTokens = error.getExpectedTokens().toString(recognizer.literalNames, recognizer.symbolicNames)

--- a/src/parse.js
+++ b/src/parse.js
@@ -3,14 +3,22 @@ import ErrorListener from './ErrorListener'
 import Expression from './Expression'
 
 export default function parse(expr, options={}) {
-  const errorListener = new ErrorListener()
+  // Could the expression be incomplete? Alters how
+  // syntax errors are reported by `ErrorListener`
+  if (options.incomplete !== false) options.incomplete = true
+
   const lexer = new MiniLexer(new InputStream(expr))
   const parser = new MiniParser(new CommonTokenStream(lexer))
   parser.buildParseTrees = true
+  
   if (!options.debug) {
     parser.removeErrorListeners()
   }
+  const errorListener = new ErrorListener({
+    incomplete: options.incomplete
+  })
   parser.addErrorListener(errorListener)
+  
   // NOTE: 'mini' is the start rule as defined in the grammar file
   let ast = parser.mini()
   let syntaxError = errorListener.syntaxErrors[0]


### PR DESCRIPTION
This is intended to reduce the noisiness of error reporting while the user is typing by ignoring errors that are generated because the `expr` is incomplete. After the user has paused for some time, or hit `Ctrl+Enter` to do an explicit evaluation, then `parse` should be called as `parse({ incomplete: false })`